### PR TITLE
Dev

### DIFF
--- a/main-merge-bams.nf
+++ b/main-merge-bams.nf
@@ -9,7 +9,8 @@ params.build_ct_index = 1
 params.outdir='output'
 
 nuclear_chroms="$params.genome" + ".nuclear.txt"
-chrom_sizes="$params.genome"  + ".chrom_sizes.bed"
+chrom_sizes="$params.genome"  + ".chrom_sizes"
+chrom_sizes_bed="$params.genome"  + ".chrom_sizes.bed"
 mappable="$params.genome" + ".K76.mappable_only.bed"
 centers="$params.genome" + ".K76.center_sites.n100.nuclear.starch"
 
@@ -33,7 +34,7 @@ process merge_bamfiles {
 	set val(indiv_id), val(cell_type), val(bam_files) from SAMPLES_AGGREGATIONS_MERGE
 
 	output:
-	set val(indiv_id), val(cell_type), file('*.bam'), file('*.bam.bai') into BAMS_MERGED_HOTSPOTS, BAMS_MERGED_COUNTS 
+	set val(indiv_id), val(cell_type), file('*.bam'), file('*.bam.bai') into BAMS_HOTSPOTS
 
 	script:
 	"""
@@ -46,28 +47,32 @@ process call_hotspots {
 	tag "${indiv_id}:${cell_type}"
 
 	// only publish varw_peaks and hotspots
-	publishDir params.outdir + '/hotspots', mode: 'symlink', pattern: "*.{varw_peaks,hotspots}.fdr*.starch" 
+	publishDir params.outdir + '/hotspots', mode: 'copy'
 
 	module "bedops/2.4.35-typical:modwt/1.0"
-
-	//scratch true
 
 	input:
 	file 'nuclear_chroms.txt' from file("${nuclear_chroms}")
 	file 'mappable.bed' from file("${mappable}")
-	file 'chrom_sizes.bed' from file("${chrom_sizes}")
+	file 'chrom_sizes.txt' from file("${chrom_sizes}")
+	file 'chrom_sizes.bed' from file("${chrom_sizes_bed}")
 	file 'centers.starch' from file("${centers}")
 
-	set val(indiv_id), val(cell_type), file(bam_file), file(bam_index_file) from BAMS_MERGED_HOTSPOTS
+	set val(indiv_id), val(cell_type), file(bam_file), file(bam_index_file) from BAMS_HOTSPOTS
 
 	output:
 	set val(indiv_id), val(cell_type), file(bam_file), file(bam_index_file), file("${indiv_id}_${cell_type}.varw_peaks.fdr0.001.starch") into PEAKS
+	file("${indiv_id}_${cell_type}.hotspots.fdr*.starch")
+	file("${indiv_id}_${cell_type}.SPOT.fdr0.05.txt")
+	file("${indiv_id}_${cell_type}.normalized.density.starch")
+	file("${indiv_id}_${cell_type}.normalized.density.bw")
 
 	script:
 	"""
-
 	TMPDIR=\$(mktemp -d)
 
+	echo "Temporary directory =  \${TMPDIR}"
+	
 	samtools view -H ${bam_file} > \${TMPDIR}/header.txt
 
 	cat nuclear_chroms.txt \
@@ -78,7 +83,7 @@ process call_hotspots {
 	PATH=/home/jvierstra/.local/src/hotspot2/bin:\$PATH
 	PATH=/home/jvierstra/.local/src/hotspot2/scripts:\$PATH
 
-	hotspot2.sh -F 0.5 -p varWidth_20_default \
+	hotspot2.sh -F 0.05 -f 0.05 -p varWidth_20_${indiv_id}_${cell_type} \
 		-M mappable.bed \
     	-c chrom_sizes.bed \
     	-C centers.starch \
@@ -92,8 +97,8 @@ process call_hotspots {
 	rm -f nuclear.varw_peaks.*
 
 	density-peaks.bash \
-		\${TMPDIR}\
-		varWidth_20_default \
+		\${TMPDIR} \
+		varWidth_20_${indiv_id}_${cell_type} \
 		nuclear.cutcounts.starch \
 		nuclear.hotspots.fdr0.001.starch \
 		../chrom_sizes.bed \
@@ -101,20 +106,66 @@ process call_hotspots {
 		nuclear.varw_peaks.fdr0.001.starch \
 		\$(cat nuclear.cleavage.total)
 
-    cp nuclear.hotspots.fdr0.05.starch ../${indiv_id}_${cell_type}.hotspots.fdr0.05.starch
-    cp nuclear.hotspots.fdr0.001.starch ../${indiv_id}_${cell_type}.hotspots.fdr0.001.starch
+	cp nuclear.varw_peaks.fdr0.001.starch ../${indiv_id}_${cell_type}.varw_peaks.fdr0.001.starch
+	cp nuclear.hotspots.fdr0.05.starch ../${indiv_id}_${cell_type}.hotspots.fdr0.05.starch
+	cp nuclear.hotspots.fdr0.001.starch ../${indiv_id}_${cell_type}.hotspots.fdr0.001.starch
+	cp nuclear.SPOT.fdr0.05.txt ../${indiv_id}_${cell_type}.SPOT.fdr0.05.txt
 
-	rm -rf \${TMPDIR}
+	tagcounts=\$(samtools view -c \${TMPDIR}/nuclear.bam)
+	echo "tagcounts = \${tagcounts}"
+
+	unstarch nuclear.density.starch \
+		| awk -v tagcount=\${tagcounts} \
+		      -v scale=1000000 \
+			  -v OFS="\\t" \
+			  '{ z=\$5; n=(z/tagcount)*scale; print \$1, \$2, \$3, \$4, n }' \
+		| starch - \
+	> ../${indiv_id}_${cell_type}.normalized.density.starch
+
+	unstarch ../${indiv_id}_${cell_type}.normalized.density.starch \
+		| awk -v OFS="\\t" \
+			  -v bin=20 \
+			  'BEGIN { \
+				  chr=""; \
+				} \
+				{ \
+					if( \$5 != 0 && \$2 != 0 ){ \
+						if( chr=="" ) { \
+							chr=\$1; \
+							print "variableStep chrom=" chr " span=" bin; \
+						} \
+						if( \$1==chr ){ \
+							print \$2, \$5; \
+						} else { \
+							chr=\$1; \
+							print "variableStep chrom=" chr " span=" bin; \
+							print \$2, \$5; \
+						} \
+					} \
+				}' \
+	> \${TMPDIR}/normalized.density.wig
+
+	wigToBigWig -clip \${TMPDIR}/normalized.density.wig ../chrom_sizes.txt ../${indiv_id}_${cell_type}.normalized.density.bw
+
 	"""
 }
 
 PEAKS.into{PEAK_LIST;PEAK_FILES}
 
+// PEAK_FILES
+// 	.map{ it -> tuple(it[1], it[3]) }
+// 	.groupTuple(by: 0)
+// 	.tap{PEAK_FILES_BY_CELLTYPE}
+// 	.map{ it -> it[1].flatten() }
+// 	.set{PEAK_FILES_ALL}
+
 PEAK_FILES
 	.map{ it -> tuple(it[1], it[4]) }
 	.groupTuple(by: 0)
 	.tap{PEAK_FILES_BY_CELLTYPE}
-	.map{ it -> tuple("all", it[1].flatten()) }
+	.map{ it -> tuple("all", it[1]) }
+	.groupTuple(by: 0)
+	.map{ it -> tuple(it[0], it[1].flatten())}
 	.set{PEAK_FILES_ALL}
 
 // Include cell-type specific indices or just one large index covering all samples
@@ -124,16 +175,17 @@ process build_index {
 	tag "${cell_type}"
 	
 	module "R/4.0.5"
+	module "bedops/2.4.35-typical"
 
-	publishDir params.outdir + '/index', mode: 'symlimk' 
+	publishDir params.outdir + '/index', mode: 'copy' 
 
 	input:
 	set val(cell_type), file('*') from PEAK_INDEX_FILES
-	file chrom_sizes from file("${chrom_sizes}")
+	file chrom_sizes from file("${chrom_sizes_bed}")
 
 	output:
 	file "masterlist*"
-	set val(cell_type), file("masterlist_DHSs_*_nonovl_core_chunkIDs.bed") into INDEX_FILES, INDEX_FILES_FOR_ANNOTATION
+	set val(cell_type), file("masterlist_DHSs_*_nonovl_any_chunkIDs.bed") into INDEX_FILES, INDEX_FILES_FOR_ANNOTATION
 
 	script:
 	"""
@@ -149,50 +201,53 @@ process build_index {
 }
 
 PEAK_LIST
-	.map{ it -> tuple(it[1], it[0], it[2], it[3], it[4])}
+	.map{ it -> tuple(it[1], it[1], it[0], it[2], it[3], it[4])}
 	.tap{ PEAK_LIST_BY_CELLTYPE }
-	.map{ it -> tuple("all", it[1], it[2], it[3], it[4])}
+	.map{ it -> tuple("all", it[1], it[2], it[3], it[4], it[5])}
 	.set{ PEAK_LIST_ALL }
 
 PEAK_LIST_COMBINED = params.build_ct_index ? PEAK_LIST_ALL.concat(PEAK_LIST_BY_CELLTYPE) : PEAK_LIST_ALL
 
 process count_tags {
-	tag "${indiv}:${cell_type}"
+	tag "${index_id}:${indiv_id}:${cell_type}"
+	
+	conda '/home/jvierstra/.local/miniconda3/envs/py3.9_default'
 
-	module "python/3.6.4"
+	publishDir params.outdir + '/counts', mode: 'symlink'
 
 	input:
-	set val(cell_type), val(indiv_id), file(bam_file), file(bam_index_file), file(peaks_file), file(index_file) from PEAK_LIST_COMBINED.combine(INDEX_FILES, by: 0)
+	set val(index_id), val(cell_type), val(indiv_id), file(bam_file), file(bam_index_file), file(peaks_file), file(index_file) from PEAK_LIST_COMBINED.combine(INDEX_FILES, by: 0)
 
 	output:
-	set val(cell_type), val(indiv_id), file("${indiv_id}_${cell_type}.counts.txt"), file("${indiv_id}_${cell_type}.bin.txt") into COUNTS_FILES
+	set val(index_id), val(cell_type), val(indiv_id), file("${index_id}_${indiv_id}_${cell_type}.counts.txt"), file("${index_id}_${indiv_id}_${cell_type}.bin.txt") into COUNTS_FILES
 
 	script:
 	"""
-	count_tags.py ${bam_file} < ${index_file} > ${indiv_id}_${cell_type}.counts.txt
+	count_tags.py ${bam_file} < ${index_file} > ${index_id}_${indiv_id}_${cell_type}.counts.txt
 	
-	bedmap --indicator ${index_file} ${peaks_file} > ${indiv_id}_${cell_type}.bin.txt
-
+	bedmap --indicator ${index_file} ${peaks_file} > ${index_id}_${indiv_id}_${cell_type}.bin.txt
 	"""
 }
 
 process generate_count_matrix {
 	tag "${cell_type}"
-
-	publishDir params.outdir + '/index', mode: 'symlink' 
+	publishDir params.outdir + '/index', mode: 'copy' 
 
 	input:
-	set val(cell_type), val(indiv_ids), file(count_files), file(bin_files), file(index_file) from COUNTS_FILES.groupTuple(by: 0).combine(INDEX_FILES_FOR_ANNOTATION, by: 0)
+	set val(index_id), val(cell_types), val(indiv_ids), file(count_files), file(bin_files), file(index_file) from COUNTS_FILES.groupTuple(by: 0).combine(INDEX_FILES_FOR_ANNOTATION, by: 0)
 
 	output:
 	file "matrix_*.txt.gz"
 
 	script:
+	col_names = [indiv_ids, cell_types].transpose().collect{e -> e.join(">") }
 	"""
 	echo -n "region_id" > header.txt
-	echo -e "\\t${indiv_ids.join("\t")}" >> header.txt
+	echo -e "\\t${col_names.join("\t")}" >> header.txt
 
-	cat header.txt <(cut -f4 ${index_file} | paste - ${count_files}) | gzip -c >  matrix_counts.${cell_type}.txt.gz
-	cat header.txt <(cut -f4 ${index_file} | paste - ${bin_files}) | gzip -c >  matrix_bin.${cell_type}.txt.gz
+	cat header.txt <(cut -f4 ${index_file} | paste - ${count_files}) | gzip -c >  matrix_counts.${index_id}.txt.gz
+	cat header.txt <(cut -f4 ${index_file} | paste - ${bin_files}) | gzip -c >  matrix_bin.${index_id}.txt.gz
 	"""
 }
+
+//COUNTS_FILES.combine(INDEX_FILES_FOR_ANNOTATION, by: 0).groupTuple(by: 0).println()

--- a/main-merge-bams.nf
+++ b/main-merge-bams.nf
@@ -66,7 +66,7 @@ process call_hotspots {
 	output:
 	set val(indiv_id), val(cell_type), file(bam_file), file(bam_index_file), file("${indiv_id}_${cell_type}.varw_peaks.fdr0.001.starch") into PEAKS
 	file("${indiv_id}_${cell_type}.hotspots.fdr*.starch")
-	file("${indiv_id}_${cell_type}.SPOT.fdr0.05.txt")
+	file("${indiv_id}_${cell_type}.SPOT.txt")
 	file("${indiv_id}_${cell_type}.normalized.density.starch")
 	file("${indiv_id}_${cell_type}.normalized.density.bw")
 

--- a/main-merge-bams.nf
+++ b/main-merge-bams.nf
@@ -52,7 +52,7 @@ process call_hotspots {
 	// only publish varw_peaks and hotspots
 	publishDir params.outdir + '/hotspots', mode: 'copy'
 
-	module "bedops/2.4.35-typical:modwt/1.0:kentutil/388"
+	module "modwt/1.0:kentutil/302:bedops/2.4.35-typical:bedtools/2.25.0:hotspot2/2.1.1:samtools/1.3"
 
 	input:
 	file 'nuclear_chroms.txt' from file("${nuclear_chroms}")
@@ -83,9 +83,6 @@ process call_hotspots {
 	| samtools reheader \${TMPDIR}/header.txt - \
 	> \${TMPDIR}/nuclear.bam
 
-	export PATH=/home/jvierstra/.local/src/hotspot2/bin:\$PATH
-	export PATH=/home/jvierstra/.local/src/hotspot2/scripts:\$PATH
-
 	hotspot2.sh -F 0.05 -f 0.05 -p varWidth_20_${indiv_id}_${cell_type} \
 		-M mappable.bed \
 		-c chrom_sizes.bed \
@@ -112,7 +109,7 @@ process call_hotspots {
 	cp nuclear.varw_peaks.fdr0.001.starch ../${indiv_id}_${cell_type}.varw_peaks.fdr0.001.starch
 	cp nuclear.hotspots.fdr0.05.starch ../${indiv_id}_${cell_type}.hotspots.fdr0.05.starch
 	cp nuclear.hotspots.fdr0.001.starch ../${indiv_id}_${cell_type}.hotspots.fdr0.001.starch
-	cp nuclear.SPOT.fdr0.05.txt ../${indiv_id}_${cell_type}.SPOT.fdr0.05.txt
+	cp nuclear.SPOT.txt ../${indiv_id}_${cell_type}.SPOT.txt
 
 	tagcounts=\$(samtools view -c \${TMPDIR}/nuclear.bam)
 	echo "tagcounts = \${tagcounts}"

--- a/main-merge-bams.nf
+++ b/main-merge-bams.nf
@@ -213,6 +213,7 @@ process count_tags {
 	tag "${index_id}:${indiv_id}:${cell_type}"
 	
 	conda '/home/jvierstra/.local/miniconda3/envs/py3.9_default'
+	module "bedops/2.4.35-typical"
 
 	publishDir params.outdir + '/counts', mode: 'symlink'
 

--- a/main-merge-bams.nf
+++ b/main-merge-bams.nf
@@ -49,7 +49,7 @@ process call_hotspots {
 	// only publish varw_peaks and hotspots
 	publishDir params.outdir + '/hotspots', mode: 'copy'
 
-	module "bedops/2.4.35-typical:modwt/1.0"
+	module "bedops/2.4.35-typical:modwt/1.0:kentutil/388"
 
 	input:
 	file 'nuclear_chroms.txt' from file("${nuclear_chroms}")
@@ -80,15 +80,15 @@ process call_hotspots {
 	| samtools reheader \${TMPDIR}/header.txt - \
 	> \${TMPDIR}/nuclear.bam
 
-	PATH=/home/jvierstra/.local/src/hotspot2/bin:\$PATH
-	PATH=/home/jvierstra/.local/src/hotspot2/scripts:\$PATH
+	export PATH=/home/jvierstra/.local/src/hotspot2/bin:\$PATH
+	export PATH=/home/jvierstra/.local/src/hotspot2/scripts:\$PATH
 
 	hotspot2.sh -F 0.05 -f 0.05 -p varWidth_20_${indiv_id}_${cell_type} \
 		-M mappable.bed \
-    	-c chrom_sizes.bed \
-    	-C centers.starch \
-    	\${TMPDIR}/nuclear.bam \
-    	peaks
+		-c chrom_sizes.bed \
+		-C centers.starch \
+		\${TMPDIR}/nuclear.bam \
+		peaks
 
 	cd peaks
 

--- a/main-merge-bams.nf
+++ b/main-merge-bams.nf
@@ -52,7 +52,7 @@ process call_hotspots {
 	// only publish varw_peaks and hotspots
 	publishDir params.outdir + '/hotspots', mode: 'copy'
 
-	module "modwt/1.0:kentutil/302:bedops/2.4.35-typical:bedtools/2.25.0:hotspot2/2.1.1:samtools/1.3"
+	module "modwt/1.0:kentutil/302:bedops/2.4.35-typical:bedtools/2.25.0:hotspot2/2.1.2:samtools/1.3"
 
 	input:
 	file 'nuclear_chroms.txt' from file("${nuclear_chroms}")

--- a/main-merge-bams.nf
+++ b/main-merge-bams.nf
@@ -147,6 +147,7 @@ process call_hotspots {
 
 	wigToBigWig -clip \${TMPDIR}/normalized.density.wig ../chrom_sizes.txt ../${indiv_id}_${cell_type}.normalized.density.bw
 
+	rm -r \${TMPDIR}
 	"""
 }
 

--- a/main-merge-bams.nf
+++ b/main-merge-bams.nf
@@ -29,7 +29,7 @@ process merge_bamfiles {
 
 	publishDir params.outdir + '/merged', mode: 'symlink' 
 
-        module "samtools/1.14"
+        module "samtools/1.3"
 
 	cpus 2
 

--- a/main-merge-bams.nf
+++ b/main-merge-bams.nf
@@ -66,7 +66,7 @@ process call_hotspots {
 	output:
 	set val(indiv_id), val(cell_type), file(bam_file), file(bam_index_file), file("${indiv_id}_${cell_type}.varw_peaks.fdr0.001.starch") into PEAKS
 	file("${indiv_id}_${cell_type}.hotspots.fdr*.starch")
-	file("${indiv_id}_${cell_type}.SPOT.txt")
+	file("${indiv_id}_${cell_type}.SPOT.fdr0.05.txt")
 	file("${indiv_id}_${cell_type}.normalized.density.starch")
 	file("${indiv_id}_${cell_type}.normalized.density.bw")
 
@@ -109,7 +109,7 @@ process call_hotspots {
 	cp nuclear.varw_peaks.fdr0.001.starch ../${indiv_id}_${cell_type}.varw_peaks.fdr0.001.starch
 	cp nuclear.hotspots.fdr0.05.starch ../${indiv_id}_${cell_type}.hotspots.fdr0.05.starch
 	cp nuclear.hotspots.fdr0.001.starch ../${indiv_id}_${cell_type}.hotspots.fdr0.001.starch
-	cp nuclear.SPOT.txt ../${indiv_id}_${cell_type}.SPOT.txt
+	cp nuclear.SPOT.fdr0.05.txt ../${indiv_id}_${cell_type}.SPOT.fdr0.05.txt
 
 	tagcounts=\$(samtools view -c \${TMPDIR}/nuclear.bam)
 	echo "tagcounts = \${tagcounts}"

--- a/main-merge-bams.nf
+++ b/main-merge-bams.nf
@@ -2,6 +2,7 @@
 
 params.samples_file = '/net/seq/data/projects/regulotyping-h.CD3+/metadata.txt'
 params.genome='/net/seq/data/genomes/human/GRCh38/noalts/GRCh38_no_alts'
+params.genome_fasta_file = "/net/seq/data/genomes/human/GRCh38/noalts/GRCh38_no_alts.fa"
 
 //Build cell-type specific indicies as well as a combined index
 params.build_ct_index = 1 
@@ -28,6 +29,8 @@ process merge_bamfiles {
 
 	publishDir params.outdir + '/merged', mode: 'symlink' 
 
+        module "samtools/1.14"
+
 	cpus 2
 
 	input:
@@ -38,7 +41,7 @@ process merge_bamfiles {
 
 	script:
 	"""
-	samtools merge -f -@${task.cpus} ${indiv_id}_${cell_type}.bam ${bam_files}
+	samtools merge -f -@${task.cpus} --reference ${params.genome_fasta_file} ${indiv_id}_${cell_type}.bam ${bam_files}
 	samtools index ${indiv_id}_${cell_type}.bam
 	"""
 }	

--- a/main-merge-bams.nf
+++ b/main-merge-bams.nf
@@ -177,8 +177,8 @@ PEAK_INDEX_FILES = params.build_ct_index ? PEAK_FILES_ALL.concat(PEAK_FILES_BY_C
 process build_index {
 	tag "${cell_type}"
 	
-	module "R/4.0.5"
-	module "bedops/2.4.35-typical"
+	module "R/4.0.5:bedops/2.4.35-typical:kentutil/388"
+	// R module should have caTools package installed
 
 	publishDir params.outdir + '/index', mode: 'copy' 
 
@@ -195,7 +195,7 @@ process build_index {
 	ls *.varw_peaks.fdr0.001.starch > filelist.txt
 
 	/home/jvierstra/.local/src/Index/run_sequential.sh \
-		\${PWD} \
+		\$(pwd) \
 		${chrom_sizes} \
 		filelist.txt \
 		${cell_type}

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,7 +18,7 @@ profiles {
 		process {
 			executor = "slurm"
 			queue = "queue0"
-			memory = { 16.GB * task.attempt }
+			memory = { 32.GB * task.attempt }
 			cache = "deep"
 			errorStrategy = { task.exitStatus == 143 ? 'retry' : 'terminate' }
 			maxRetries = 3

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,7 +17,7 @@ profiles {
 		// Run on SLURM and load the appropriate modules	
 		process {
 			executor = "slurm"
-			queue = "queue0"
+			queue = "queue0,pool,bigmem"
 			memory = { 32.GB * task.attempt }
 			cache = "deep"
 			errorStrategy = { task.exitStatus == 143 ? 'retry' : 'terminate' }


### PR DESCRIPTION
The current main branch version crashes on hotspot_calling step because files listed as outputs are not renamed.
Changes:
* incorporate unpublished working code from Jeff's project directory 
* quick&dirty fix to handle Altius cram files with inside link to (nonexistent) tmp reference
* module incorporation
* queue list update in the config

Current code does not fix missing R caTools dependency. Better to refactor all deps to conda at some point.